### PR TITLE
Scale items: Refactor Code To Allow Scaling Of Items

### DIFF
--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -90,7 +90,7 @@ function diag_gear(x, y, width, height) {
     const items = [];
 
     var tf_str = 'translate(' + x.toString() + ', ' + y.toString() + ') scale(2, 2)';
-    const gear_group = svg_group({'transform':tf_str}, {'stroke-width':'1'});
+    const gear_group = svg_group({'transform':tf_str, 'stroke-width':'1'});
     items.push(gear_group);
 
     const circle_attribs = {};

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -79,14 +79,15 @@ function diag_message_store(x, y, width, height, opts) {
 
     const x_off = 2 * unit_width;
 
-    var tf_str = 'translate(' + x_off.toString() + ', ' + (-hh).toString() + ') scale(1, 1)';
+    // var tf_str = 'translate(' + x_off.toString() + ', ' + (-hh).toString() + ') scale(1, 1)';
+    var tf_str = 'translate(' + x + ', ' + y + ') scale(1.5, 1.5)';
     const message_store_group = svg_group({'transform':tf_str});
     items.push(message_store_group);
 
-    message_store_group.appendChild(create_side_cover(x, y, height, opts));
+    message_store_group.appendChild(create_side_cover(0 + x_off, 0 - hh, height, opts));
 
     for (var i = 0;i < bands; ++i) {
-        message_store_group.appendChild(create_side_band((x - unit_width * i) + (4 * i) + (i * adj_w), y, width, height, 0, unit_width));
+        message_store_group.appendChild(create_side_band((x_off - unit_width * i) + (4 * i) + (i * adj_w), -hh, width, height, 0, unit_width));
     }
 
     items.push(svg_circle(x, y, 5, {'fill':'red'}));

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -89,16 +89,16 @@ function diag_message_store(x, y, width, height, opts) {
 function diag_gear(x, y, width, height) {
     const items = [];
 
+    var tf_str = 'translate(' + x.toString() + ', ' + y.toString() + ') scale(2, 2)';
+    const gear_group = svg_group({'transform':tf_str}, {'stroke-width':'1'});
+    items.push(gear_group);
+
     const circle_attribs = {};
     circle_attribs['stroke']="black";
     circle_attribs['stroke-width']="10";
     circle_attribs['fill']="none";
 
-    items.push(svg_circle(x, y, 40, circle_attribs));
-
-    var tf_str = 'translate(' + x.toString() + ', ' + y.toString() + ')';
-    const gear_group = svg_group({'transform':tf_str}, {'stroke-width':'1'});
-    items.push(gear_group);
+    gear_group.appendChild(svg_circle(0, 0, 40, circle_attribs));
     
     var path_d = "m0,-43 l-10,0 l3,-10 l14,0 l3,10 z";
     gear_group.appendChild(svg_path(path_d));

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -29,8 +29,12 @@ function diag_db(x, y, width, height) {
     const hw = width / 2;
     const hh = height / 2;
 
-    items.push(create_data_top(x - hw, y - hh, width, height));
-    items.push(create_flexible_band(x - hw, y - hh, width, height, 0));
+    var tf_str = 'translate(' + (- hw).toString() + ', ' + (-hh).toString() + ') scale(1, 1)';
+    const db_group = svg_group({'transform':tf_str});
+    items.push(db_group);
+
+    db_group.appendChild(create_data_top(x, y, width, height));
+    db_group.appendChild(create_flexible_band(x, y, width, height, 0));
 
     items.push(svg_circle(x, y, 5, {'fill':'red'}));
     return items;

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -58,10 +58,16 @@ function diag_file_store(x, y, width, height) {
     const hw = width / 2;
     const y_off = (1.5 * tri_height) + 7;
 
-    items.push(create_data_top(x - hw, y - y_off, width, height));
-    items.push(create_flexible_band(x - hw, y - y_off, width, tri_height, 0));
-    items.push(create_flexible_band(x - hw, y + tri_height + 5 - y_off, width, tri_height, 0));
-    items.push(create_flexible_band(x - hw, (y + 2 * tri_height) + 10 - y_off, width, tri_height, 0));
+    var tf_str = 'translate(' + x + ', ' + y + ') scale(1.5, 1.5)';
+    const file_store_group = svg_group({'transform':tf_str});
+    items.push(file_store_group);
+
+    // message_store_group.appendChild(create_side_cover(0 + x_off, 0 - hh, height, opts));
+
+    file_store_group.appendChild(create_data_top(- hw, - y_off, width, height));
+    file_store_group.appendChild(create_flexible_band(- hw, - y_off, width, tri_height, 0));
+    file_store_group.appendChild(create_flexible_band(- hw, tri_height + 5 - y_off, width, tri_height, 0));
+    file_store_group.appendChild(create_flexible_band(- hw, (2 * tri_height) + 10 - y_off, width, tri_height, 0));
 
     items.push(svg_circle(x, y, 5, {'fill':'red'}));
     return items;
@@ -79,7 +85,6 @@ function diag_message_store(x, y, width, height, opts) {
 
     const x_off = 2 * unit_width;
 
-    // var tf_str = 'translate(' + x_off.toString() + ', ' + (-hh).toString() + ') scale(1, 1)';
     var tf_str = 'translate(' + x + ', ' + y + ') scale(1.5, 1.5)';
     const message_store_group = svg_group({'transform':tf_str});
     items.push(message_store_group);

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -29,12 +29,12 @@ function diag_db(x, y, width, height) {
     const hw = width / 2;
     const hh = height / 2;
 
-    var tf_str = 'translate(' + (- hw).toString() + ', ' + (-hh).toString() + ') scale(1, 1)';
+    var tf_str = 'translate(' + x + ', ' + y + ') scale(1.5, 1.5)';
     const db_group = svg_group({'transform':tf_str});
     items.push(db_group);
 
-    db_group.appendChild(create_data_top(x, y, width, height));
-    db_group.appendChild(create_flexible_band(x, y, width, height, 0));
+    db_group.appendChild(create_data_top(- hw, -hh, width, height));
+    db_group.appendChild(create_flexible_band(- hw, -hh, width, height, 0));
 
     items.push(svg_circle(x, y, 5, {'fill':'red'}));
     return items;

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -45,8 +45,12 @@ function diag_object_store(x, y, width, height) {
     const hw = width / 2;
     const hh = height / 2;
 
-    items.push(create_data_top(x - hw, y - hh, width, height));
-    items.push(create_flexible_band(x - hw, y - hh, width, height, 25));
+    var tf_str = 'translate(' + x + ', ' + y + ') scale(1.5, 1.5)';
+    const object_store_group = svg_group({'transform':tf_str});
+    items.push(object_store_group);
+
+    object_store_group.appendChild(create_data_top(- hw, - hh, width, height));
+    object_store_group.appendChild(create_flexible_band(- hw, - hh, width, height, 25));
 
     items.push(svg_circle(x, y, 5, {'fill':'red'}));
     return items;
@@ -61,8 +65,6 @@ function diag_file_store(x, y, width, height) {
     var tf_str = 'translate(' + x + ', ' + y + ') scale(1.5, 1.5)';
     const file_store_group = svg_group({'transform':tf_str});
     items.push(file_store_group);
-
-    // message_store_group.appendChild(create_side_cover(0 + x_off, 0 - hh, height, opts));
 
     file_store_group.appendChild(create_data_top(- hw, - y_off, width, height));
     file_store_group.appendChild(create_flexible_band(- hw, - y_off, width, tri_height, 0));

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -124,7 +124,7 @@ function diag_transform(x, y, width, height) {
     circle_attribs['stroke-width']="1";
     circle_attribs['fill']="none";
     
-    var tf_str = 'translate(' + x.toString() + ', ' + y.toString() + ')';
+    var tf_str = 'translate(' + x.toString() + ', ' + y.toString() + ') scale(2, 2)';
     const transform_group = svg_group({'transform':tf_str, 'stroke':'black', 'fill':'none', "stroke-width":line_width});
     items.push(transform_group);
 

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -75,10 +75,14 @@ function diag_message_store(x, y, width, height, opts) {
 
     const x_off = 2 * unit_width;
 
-    items.push(create_side_cover(x + x_off, y - hh, height, opts));
+    var tf_str = 'translate(' + x_off.toString() + ', ' + (-hh).toString() + ')';
+    const message_store_group = svg_group({'transform':tf_str});
+    items.push(message_store_group);
+
+    message_store_group.appendChild(create_side_cover(x, y, height, opts));
 
     for (var i = 0;i < bands; ++i) {
-        items.push(create_side_band((x - unit_width * i) + (4 * i) + (i * adj_w) + x_off, y - hh, width, height, 0, unit_width));
+        message_store_group.appendChild(create_side_band((x - unit_width * i) + (4 * i) + (i * adj_w), y, width, height, 0, unit_width));
     }
 
     items.push(svg_circle(x, y, 5, {'fill':'red'}));

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -75,7 +75,7 @@ function diag_message_store(x, y, width, height, opts) {
 
     const x_off = 2 * unit_width;
 
-    var tf_str = 'translate(' + x_off.toString() + ', ' + (-hh).toString() + ')';
+    var tf_str = 'translate(' + x_off.toString() + ', ' + (-hh).toString() + ') scale(1, 1)';
     const message_store_group = svg_group({'transform':tf_str});
     items.push(message_store_group);
 

--- a/svg_basic.html
+++ b/svg_basic.html
@@ -19,7 +19,7 @@
     const x3 = 800;
 
     const y1 = 200;
-    const y2 = 400;
+    const y2 = 450;
 
     var svg = document.getElementById('my_svg');
 
@@ -37,9 +37,6 @@
     diag.appendMulti(diag_gear(x2, y2, 150, 70));
     diag.appendMulti(diag_transform(x3, y2, 40, 70));
     diag.render();
-
-    var x = 4;
-    var y = x + 2;
 
 </script>
 </body>

--- a/svg_basic.html
+++ b/svg_basic.html
@@ -14,21 +14,28 @@
  
 <script>
 
+    const x1 = 200;
+    const x2 = 500;
+    const x3 = 800;
+
+    const y1 = 200;
+    const y2 = 400;
+
     var svg = document.getElementById('my_svg');
 
     const diag = new DataFlowDiagram(svg);
-    diag.appendMulti(diag_db(130, 200, 150, 100));
-    diag.appendMulti(diag_object_store(430, 200, 150, 100));
-    diag.appendMulti(diag_file_store(730, 200, 150, 100));
+    diag.appendMulti(diag_db(x1, y1, 150, 100));
+    diag.appendMulti(diag_object_store(x2, y1, 150, 100));
+    diag.appendMulti(diag_file_store(x3, y1, 150, 100));
     var opts = new Map();
     opts.set('offset', 3);
     opts.set('bands', 4);
-    diag.appendMulti(diag_message_store(130, 400, 150, 70, opts));
+    diag.appendMulti(diag_message_store(x1, y2, 150, 70, opts));
     opts = new Map();
     opts.set('offset', 3);
     opts.set('bands', 4);
-    diag.appendMulti(diag_gear(430, 400, 150, 70));
-    diag.appendMulti(diag_transform(730, 400, 40, 70));
+    diag.appendMulti(diag_gear(x2, y2, 150, 70));
+    diag.appendMulti(diag_transform(x3, y2, 40, 70));
     diag.render();
 
     var x = 4;


### PR DESCRIPTION
This PR is for refactoring the code to allow for scaling of items. Previously items were drawn at their xy location and when they were made up of multiple pieces those items would also be drawn relative to the xy. The change that was applied was to create a top level group which would contain the items. The group would be drawn at the xy while the pieces of the items were drawn in their relative positions.  The drawing of the items was also refactored to support x and y variables that aligned items as they were moved because of different size changes.