### PR TITLE
new-items: Implement Server Diagram Item

### DIFF
--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -201,3 +201,32 @@ function diag_transform(x, y, width, height) {
     items.push(svg_circle(x, y, 5, {'fill':'red'}));
     return items;
 }
+
+function diag_server(x, y, width, height) {
+    const items = [];
+    const hw = width / 2;
+    const hh = height / 2;
+
+    var tf_str = 'translate(' + x + ', ' + y + ') scale(1.5, 1.5)';
+    const db_group = svg_group({'transform':tf_str});
+    items.push(db_group);
+
+    const x_off = 11;
+    const y_start = 13;
+    const drive_height_pctg = .07;
+    const drive_off_pctg = .021;
+
+    const drive_x = - hw + x_off;
+    const drive_y = -hh + y_start;
+    const drive_width = width - (x_off * 2);
+    const drive_height = height * drive_height_pctg;
+    const drive_attribs = {'rx':'2', 'ry':'2', 'fill':'gray'};
+
+    db_group.appendChild(svg_rect(- hw, -hh, width, height, {'rx':'5', 'ry':'5'}));
+    db_group.appendChild(svg_rect(drive_x, drive_y, drive_width, drive_height, drive_attribs));
+    db_group.appendChild(svg_rect(drive_x, drive_y + drive_height + (height * drive_off_pctg), drive_width, drive_height, drive_attribs));
+    db_group.appendChild(svg_rect(drive_x, drive_y + (2 * (drive_height + (height * drive_off_pctg))), drive_width, drive_height, drive_attribs));
+
+    items.push(svg_circle(x, y, 5, {'fill':'red'}));
+    return items;
+}

--- a/js/svg_core.js
+++ b/js/svg_core.js
@@ -50,3 +50,17 @@ function svg_group(attribs) {
 
     return element;
 }
+
+function svg_rect(x, y, w, h, attribs) {
+    var element = document.createElementNS(SVG_NS, 'rect');
+    element.setAttribute('x', x);
+    element.setAttribute('y', y);
+    element.setAttribute('width', w);
+    element.setAttribute('height', h);
+
+    if (attribs !== undefined) {
+        attrib_set(element, attribs);
+    }
+
+    return element;
+}

--- a/svg_basic.html
+++ b/svg_basic.html
@@ -24,7 +24,7 @@
     var svg = document.getElementById('my_svg');
 
     const diag = new DataFlowDiagram(svg);
-    diag.appendMulti(diag_db(x1, y1, 150, 100));
+    diag.appendMulti(diag_server(x1, y1, 100, 150));
     diag.appendMulti(diag_object_store(x2, y1, 150, 100));
     diag.appendMulti(diag_file_store(x3, y1, 150, 100));
     var opts = new Map();


### PR DESCRIPTION
This PR is for the implementation of the Server Diagram Item. The changes to each file are outlined below.

#### svg_basic.html
Replaced diag_db with diag_server to display new item. Width and height were changed to reflect the dimensions of the server. This change pointed to a core underlying issue which is that the diag factory functions should not need or even take in the dimensions of the item. This should be done via another way, possibly a global config.

#### js/svg_core.js
Added implementation of the rect element which is what the Server Diagram Item utilizes.

#### js/diag_factory.js
Implementation of diag_server. Refactoring will be needed later.


