### PR TITLE
click-drag: Enable click-drag functionality for items.

### DIFF
--- a/all_item_display.html
+++ b/all_item_display.html
@@ -35,7 +35,7 @@
     diag.drawImmediateMulti(diag.diag_object_store(x1 + y1_x_off, y1));
     diag.drawImmediateMulti(diag.diag_file_store(x1 + (2 * y1_x_off), y1));
 
-    diag.drawImmediateMulti(diag_message_store(x1, y2));
+    diag.drawImmediateMulti(diag.diag_message_store(x1, y2));
 
     diag.drawImmediateMulti(diag_gear(x1, y3));
     diag.drawImmediateMulti(diag_transform(x1 + y3_x_off, y3));

--- a/all_item_display.html
+++ b/all_item_display.html
@@ -37,8 +37,8 @@
 
     diag.drawImmediateMulti(diag.diag_message_store(x1, y2));
 
-    diag.drawImmediateMulti(diag_gear(x1, y3));
-    diag.drawImmediateMulti(diag_transform(x1 + y3_x_off, y3));
+    diag.drawImmediateMulti(diag.diag_gear(x1, y3));
+    diag.drawImmediateMulti(diag.diag_transform(x1 + y3_x_off, y3));
     
     diag.drawImmediateMulti(diag_server(x1, y4));
     diag.drawImmediateMulti(diag_flatfile(x1 + y1_x_off, y4));

--- a/all_item_display.html
+++ b/all_item_display.html
@@ -32,7 +32,7 @@
 
     const diag = new DataFlowDiagram(svg);
     diag.drawImmediateMulti(diag.diag_db(x1, y1));
-    diag.drawImmediateMulti(diag_object_store(x1 + y1_x_off, y1));
+    diag.drawImmediateMulti(diag.diag_object_store(x1 + y1_x_off, y1));
     diag.drawImmediateMulti(diag_file_store(x1 + (2 * y1_x_off), y1));
 
     diag.drawImmediateMulti(diag_message_store(x1, y2));

--- a/all_item_display.html
+++ b/all_item_display.html
@@ -42,8 +42,8 @@
     
     diag.drawImmediateMulti(diag.diag_server(x1, y4));
     diag.drawImmediateMulti(diag.diag_flatfile(x1 + y1_x_off, y4));
-    diag.drawImmediateMulti(diag_report(x1 + (2 * y1_x_off), y4));
-    diag.drawImmediateMulti(diag_screen(x1 + (3 * y1_x_off), y4));
+    diag.drawImmediateMulti(diag.diag_report(x1 + (2 * y1_x_off), y4));
+    diag.drawImmediateMulti(diag.diag_screen(x1 + (3 * y1_x_off), y4));
 
 </script>
 </body>

--- a/all_item_display.html
+++ b/all_item_display.html
@@ -40,8 +40,8 @@
     diag.drawImmediateMulti(diag.diag_gear(x1, y3));
     diag.drawImmediateMulti(diag.diag_transform(x1 + y3_x_off, y3));
     
-    diag.drawImmediateMulti(diag_server(x1, y4));
-    diag.drawImmediateMulti(diag_flatfile(x1 + y1_x_off, y4));
+    diag.drawImmediateMulti(diag.diag_server(x1, y4));
+    diag.drawImmediateMulti(diag.diag_flatfile(x1 + y1_x_off, y4));
     diag.drawImmediateMulti(diag_report(x1 + (2 * y1_x_off), y4));
     diag.drawImmediateMulti(diag_screen(x1 + (3 * y1_x_off), y4));
 

--- a/all_item_display.html
+++ b/all_item_display.html
@@ -33,7 +33,7 @@
     const diag = new DataFlowDiagram(svg);
     diag.drawImmediateMulti(diag.diag_db(x1, y1));
     diag.drawImmediateMulti(diag.diag_object_store(x1 + y1_x_off, y1));
-    diag.drawImmediateMulti(diag_file_store(x1 + (2 * y1_x_off), y1));
+    diag.drawImmediateMulti(diag.diag_file_store(x1 + (2 * y1_x_off), y1));
 
     diag.drawImmediateMulti(diag_message_store(x1, y2));
 

--- a/all_item_display.html
+++ b/all_item_display.html
@@ -31,7 +31,7 @@
     var svg = document.getElementById('my_svg');
 
     const diag = new DataFlowDiagram(svg);
-    diag.drawImmediateMulti(diag_db(x1, y1));
+    diag.drawImmediateMulti(diag.diag_db(x1, y1));
     diag.drawImmediateMulti(diag_object_store(x1 + y1_x_off, y1));
     diag.drawImmediateMulti(diag_file_store(x1 + (2 * y1_x_off), y1));
 

--- a/click_add_item.html
+++ b/click_add_item.html
@@ -56,9 +56,9 @@ function svg_mouse_down(e) {
     } else if (opt == 'message_store') {
         item = diag.diag_message_store(xPosition, yPosition, sz_int);
     } else if (opt == 'gear') {
-        item_fn = diag_gear;
+        item = diag.diag_gear(xPosition, yPosition, sz_int);
     } else if (opt == 'transform') {
-        item_fn = diag_transform;
+        item = diag.diag_transform(xPosition, yPosition, sz_int);
     } else if (opt == 'server') {
         item_fn = diag_server;
     } else if (opt == 'flat_file') {

--- a/click_add_item.html
+++ b/click_add_item.html
@@ -52,7 +52,7 @@ function svg_mouse_down(e) {
     } else if (opt == 'object_store') {
         item = diag.diag_object_store(xPosition, yPosition, sz_int);
     } else if (opt == 'file_store') {
-        item_fn = diag_file_store;
+        item = diag.diag_file_store(xPosition, yPosition, sz_int);
     } else if (opt == 'message_store') {
         item_fn = diag_message_store;
     } else if (opt == 'gear') {

--- a/click_add_item.html
+++ b/click_add_item.html
@@ -48,7 +48,7 @@ function svg_mouse_down(e) {
     var item_fn = null;
     
     if (opt == 'database') {
-        item_fn = diag_db;
+        item = diag.diag_db(xPosition, yPosition, sz_int);
     } else if (opt == 'object_store') {
         item_fn = diag_object_store;
     } else if (opt == 'file_store') {
@@ -71,8 +71,8 @@ function svg_mouse_down(e) {
     
     if (item_fn != null) {
         item = item_fn(xPosition, yPosition, sz_int);
-        diag.drawImmediateMulti(item);
     }
+    diag.drawImmediateMulti(item);
 }
 
 var svg = document.getElementById('my_svg');

--- a/click_add_item.html
+++ b/click_add_item.html
@@ -60,9 +60,9 @@ function svg_mouse_down(e) {
     } else if (opt == 'transform') {
         item = diag.diag_transform(xPosition, yPosition, sz_int);
     } else if (opt == 'server') {
-        item_fn = diag_server;
+        item = diag.diag_server(xPosition, yPosition, sz_int);
     } else if (opt == 'flat_file') {
-        item_fn = diag_flatfile;
+        item = diag.diag_flatfile(xPosition, yPosition, sz_int);
     } else if (opt == 'report') {
         item_fn = diag_report;
     } else if (opt == 'screen') {

--- a/click_add_item.html
+++ b/click_add_item.html
@@ -50,7 +50,7 @@ function svg_mouse_down(e) {
     if (opt == 'database') {
         item = diag.diag_db(xPosition, yPosition, sz_int);
     } else if (opt == 'object_store') {
-        item_fn = diag_object_store;
+        item = diag.diag_object_store(xPosition, yPosition, sz_int);
     } else if (opt == 'file_store') {
         item_fn = diag_file_store;
     } else if (opt == 'message_store') {

--- a/click_add_item.html
+++ b/click_add_item.html
@@ -64,9 +64,9 @@ function svg_mouse_down(e) {
     } else if (opt == 'flat_file') {
         item = diag.diag_flatfile(xPosition, yPosition, sz_int);
     } else if (opt == 'report') {
-        item_fn = diag_report;
+        item = diag.diag_report(xPosition, yPosition, sz_int);
     } else if (opt == 'screen') {
-        item_fn = diag_screen;
+        item = diag.diag_screen(xPosition, yPosition, sz_int);
     }
     
     if (item_fn != null) {

--- a/click_add_item.html
+++ b/click_add_item.html
@@ -54,7 +54,7 @@ function svg_mouse_down(e) {
     } else if (opt == 'file_store') {
         item = diag.diag_file_store(xPosition, yPosition, sz_int);
     } else if (opt == 'message_store') {
-        item_fn = diag_message_store;
+        item = diag.diag_message_store(xPosition, yPosition, sz_int);
     } else if (opt == 'gear') {
         item_fn = diag_gear;
     } else if (opt == 'transform') {

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -341,7 +341,7 @@ DataFlowDiagram.prototype.diag_message_store = function(x, y, scale_factor) {
     return items;
 }
 
-function diag_gear(x, y, scale_factor) {
+DataFlowDiagram.prototype.diag_gear = function(x, y, scale_factor) {
     const items = [];
 
     const width = 150;
@@ -352,7 +352,7 @@ function diag_gear(x, y, scale_factor) {
 
 
     const diag_type = 'gear';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
+    const diag_group = this.core_group(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
     items.push(diag_group);
 
     const circle_attribs = {};
@@ -376,7 +376,7 @@ function diag_gear(x, y, scale_factor) {
     return items;
 }
 
-function diag_transform(x, y, scale_factor) {
+DataFlowDiagram.prototype.diag_transform = function(x, y, scale_factor) {
     const items = [];
 
     const width = 40;
@@ -386,7 +386,7 @@ function diag_transform(x, y, scale_factor) {
     const box_height_scale = 1.1;
 
     const diag_type = 'transform';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
+    const diag_group = this.core_group(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
     items.push(diag_group);
 
     const item_size = 3;

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -189,29 +189,6 @@ function diag_mousemove_handler(e) {
     }
 }
 
-function core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale) {
-
-    const box_w = width * box_width_scale;
-    const box_h = height * box_height_scale;
-
-    const hbw = box_w / 2;
-    const hbh = box_h / 2;
-
-    const bounds_rect = svg_rect(- hbw, -hbh, box_w, box_h, DIAG_ITEM_BG_RECT);
-    
-    const s_factor = scale_factor || 1.0;
-    var tf_str = 'translate(' + x + ', ' + y + ') scale(' + s_factor.toString() + ',' + s_factor.toString() + ')';
-    const diag_group = svg_group({'transform':tf_str});
-    diag_group.setAttribute(DIAG_TYPE_ATTR, diag_type);
-    diag_group.addEventListener("mousedown", diag_mousedown_handler, false);
-    diag_group.addEventListener("mouseup", diag_mouseup_handler, false);
-    diag_group.addEventListener("mousemove", diag_mousemove_handler, false);
-    bounds_rect.setAttribute(DIAG_SHOW_BOUNDS, false);
-    bounds_rect.style.visibility = 'hidden';
-    diag_group.appendChild(bounds_rect);
-    return diag_group;
-}
-
 DataFlowDiagram.prototype.core_group = function(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale) {
 
     const box_w = width * box_width_scale;

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -117,36 +117,6 @@ DataFlowDiagram.prototype.setInteractiveMode = function(mode) {
     }
 }
 
-function diag_mousedown_handler(e) {
-    const el = this;
-    if (el.getAttribute(DIAG_INT_MODE_ATTR) == DIAG_INTERACTIVE_MOVE) {
-        initialX = e.offsetX;
-        initialY = e.offsetY;
-        const dbstr = 'initial x: ' + initialX.toString() + ' y: ' + initialY.toString()
-        active_item = el;
-        const bv = active_item.transform.baseVal;
-        for (var i = 0;i < bv.length; ++i) {
-            var tf = bv[i];
-            if (tf.type == TRANSFORM_TRANSLATE_VAL) {
-                elementX = tf.matrix.e;
-                elementY = tf.matrix.f;
-            }
-            else if (tf.type == TRANSFORM_SCALE_VAL) {
-                elementScaleX = tf.matrix.a;
-                elementScaleY = tf.matrix.d;
-            }
-            else if (tf.type == TRANSFORM_TRANSLATE_SCALE_VAL) {
-                elementX = tf.matrix.e;
-                elementY = tf.matrix.f;
-                elementScaleX = tf.matrix.a;
-                elementScaleY = tf.matrix.d;
-
-            }
-        }
-        e.stopPropagation();    
-    }
-}
-
 function diag_mouseup_handler(e) {
     const el = this;
     if (el.getAttribute(DIAG_INT_MODE_ATTR) == DIAG_INTERACTIVE_MOVE) {
@@ -159,33 +129,6 @@ function diag_mouseup_handler(e) {
         }
         active_item = null;
         e.stopPropagation();
-    }
-}
-
-function diag_mousemove_handler(e) {
-    const el = this;
-    if (el.getAttribute(DIAG_INT_MODE_ATTR) == DIAG_INTERACTIVE_MOVE) {
-        if (active_item != null) {
-            const currentX = e.offsetX;
-            const currentY = e.offsetY;
-            const deltaX = currentX - initialX;
-            const deltaY = currentY - initialY;
-            const nX = (elementX + deltaX).toString();
-            const nY = (elementY + deltaY).toString();
-            const dbstr = 'move x: ' + nX.toString() + ' y: ' + nY.toString()
-            // console.log(dbstr);
-            el.setAttribute('transform', 'translate(' + nX + ', ' + nY + ')')
-            const bv = active_item.transform.baseVal;
-            for (var i = 0;i < bv.length; ++i) {
-                var tf = bv[i];
-                if (tf.type == TRANSFORM_TRANSLATE_VAL) {
-                    tf.matrix.e = elementX + deltaX;
-                    tf.matrix.f = elementY + deltaY;
-                    break;
-                }
-            }
-                e.stopPropagation();
-        }
     }
 }
 

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -279,7 +279,7 @@ DataFlowDiagram.prototype.diag_object_store = function(x, y, scale_factor) {
     return items;
 }
 
-function diag_file_store(x, y, scale_factor) {
+DataFlowDiagram.prototype.diag_file_store = function(x, y, scale_factor) {
     const items = [];
 
     const width = 150;
@@ -289,7 +289,7 @@ function diag_file_store(x, y, scale_factor) {
     const box_height_scale = 1.6;
 
     const diag_type = 'file_store';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
+    const diag_group = this.core_group(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
     items.push(diag_group);
 
     const tri_height = height / 3;

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -532,7 +532,7 @@ DataFlowDiagram.prototype.diag_flatfile = function(x, y, scale_factor) {
     return items;
 }
 
-function diag_report(x, y, scale_factor) {
+DataFlowDiagram.prototype.diag_report = function(x, y, scale_factor) {
     const items = [];
 
     const width = 150;
@@ -542,7 +542,7 @@ function diag_report(x, y, scale_factor) {
     const box_height_scale = 1.4;
 
     const diag_type = 'report';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
+    const diag_group = this.core_group(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
     items.push(diag_group);
 
     const rpt_attribs = {'rx':'5', 'ry':'5', 'fill':'none', 'stroke':'black', 'stroke-width':'5'};
@@ -561,7 +561,7 @@ function diag_report(x, y, scale_factor) {
     return items;
 }
 
-function diag_screen(x, y, scale_factor) {
+DataFlowDiagram.prototype.diag_screen = function(x, y, scale_factor) {
     const items = [];
 
     const width = 150;
@@ -571,7 +571,7 @@ function diag_screen(x, y, scale_factor) {
     const box_height_scale = 1.4;
 
     const diag_type = 'screen';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
+    const diag_group = this.core_group(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
     items.push(diag_group);
 
     const hw = width / 2;

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -304,7 +304,7 @@ DataFlowDiagram.prototype.diag_file_store = function(x, y, scale_factor) {
     return items;
 }
 
-function diag_message_store(x, y, scale_factor) {
+DataFlowDiagram.prototype.diag_message_store = function(x, y, scale_factor) {
     const items = [];
 
     const opts = new Map();
@@ -318,7 +318,7 @@ function diag_message_store(x, y, scale_factor) {
     const box_height_scale = 1;
 
     const diag_type = 'message_store';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
+    const diag_group = this.core_group(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
     items.push(diag_group);
 
     const hh = height / 2;

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -257,28 +257,6 @@ DataFlowDiagram.prototype.diag_db = function(x, y, scale_factor) {
     return items;
 }
 
-function diag_db(x, y, scale_factor) {
-    const items = [];
-
-    const width = 150;
-    const height = 100;
-
-    const box_width_scale = 1;
-    const box_height_scale = 1.5;
-
-    const diag_type = 'database';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
-    items.push(diag_group);
-
-    const hw = width / 2;
-    const hh = height / 2;
-
-    diag_group.appendChild(create_data_top(- hw, -hh, width, height));
-    diag_group.appendChild(create_flexible_band(- hw, -hh, width, height, 0));
-    diag_group.appendChild(svg_circle(0, 0, 5, {'fill':'blue'}));
-    return items;
-}
-
 function diag_object_store(x, y, scale_factor) {
     const items = [];
 

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -257,7 +257,7 @@ DataFlowDiagram.prototype.diag_db = function(x, y, scale_factor) {
     return items;
 }
 
-function diag_object_store(x, y, scale_factor) {
+DataFlowDiagram.prototype.diag_object_store = function(x, y, scale_factor) {
     const items = [];
 
     const width = 150;
@@ -267,7 +267,7 @@ function diag_object_store(x, y, scale_factor) {
     const box_height_scale = 1.5;
     
     const diag_type = 'object_store';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
+    const diag_group = this.core_group(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
     items.push(diag_group);
 
     const hw = width / 2;

--- a/js/diag_factory.js
+++ b/js/diag_factory.js
@@ -450,7 +450,7 @@ DataFlowDiagram.prototype.diag_transform = function(x, y, scale_factor) {
     return items;
 }
 
-function diag_server(x, y, scale_factor) {
+DataFlowDiagram.prototype.diag_server = function(x, y, scale_factor) {
     const items = [];
 
     const width = 100;
@@ -460,7 +460,7 @@ function diag_server(x, y, scale_factor) {
     const box_height_scale = 1.1;
 
     const diag_type = 'server';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
+    const diag_group = this.core_group(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
     items.push(diag_group);
 
     const hw = width / 2;
@@ -496,7 +496,7 @@ function diag_server(x, y, scale_factor) {
     return items;
 }
 
-function diag_flatfile(x, y, scale_factor) {
+DataFlowDiagram.prototype.diag_flatfile = function(x, y, scale_factor) {
     const items = [];
 
     const width = 100;
@@ -506,7 +506,7 @@ function diag_flatfile(x, y, scale_factor) {
     const box_height_scale = .9;
 
     const diag_type = 'flatfile';
-    const diag_group = core_diag_grouping2(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
+    const diag_group = this.core_group(x, y, scale_factor, diag_type, width, height, box_width_scale, box_height_scale)
     items.push(diag_group);
 
     const x_scale = 8.5;


### PR DESCRIPTION
Refactored code to mostly fall under the DataFlowDiagram object. Previously there were issues with tracking the object when the mouse was no longer over the object. There are still issues but as long as the mouse cursor stays on the svg canvas functionality should work.